### PR TITLE
Changed how we read OnlyEvenWeeks/OnlyOddWeeks from XML-document.

### DIFF
--- a/Stadtruppen/script.js
+++ b/Stadtruppen/script.js
@@ -303,10 +303,10 @@ function extractCleaningInfo(i) {
   //oddEven
   info.oddEven = 2;
   if (
-    typeof xml_cleaningZones.getElementsByTagName("OnlyEvenWeeks")[i] ==
-      "undefined" &&
-    typeof xml_cleaningZones.getElementsByTagName("OnlyOddWeeks")[i] ==
-      "undefined"
+    typeof xml_cleaningZones.getElementsByTagName("CleaningZone")[i].getElementsByTagName("OnlyEvenWeeks")[0] ==
+          "undefined" &&
+        typeof xml_cleaningZones.getElementsByTagName("CleaningZone")[i].getElementsByTagName("OnlyOddWeeks")[0] ==
+          "undefined"
   ) {
     info.oddEven = 1;
   }


### PR DESCRIPTION
Here is an example for how to do it correctly: xml_cleaningZones.getElementsByTagName("CleaningZone")[i].getElementsByTagName("OnlyEvenWeeks")[0]